### PR TITLE
added role subs to team member icons

### DIFF
--- a/app/containers/ProjectView/index.js
+++ b/app/containers/ProjectView/index.js
@@ -64,8 +64,10 @@ export class ProjectView extends React.Component { // eslint-disable-line react/
         return this.props.projectview.leadership.map((leadership) => {
           return(
             <div key={Math.random()} className="col-md-4">
-                <img style={{width:'50px', height:'50px', borderRadius:'50%' }} src={Avatar} />
-                <span> {leadership.firstName} </span>
+                {/* I'd like better icons so we don't have to have a negative margin */}
+                <img style={{width:'50px', height:'50px', borderRadius:'50%', marginLeft: '-6px' }} src={Avatar} />
+                <span>{leadership.firstName}</span>
+                <div>{leadership.role}</div>
             </div>
           )
         });
@@ -78,8 +80,10 @@ export class ProjectView extends React.Component { // eslint-disable-line react/
         return this.props.projectview.team.map((team) => {
           return(
             <div key={Math.random()} className="col-md-4">
-              <img style={{width:'50px', height:'50px', borderRadius:'50%' }} src={Avatar} />
-              <span> {team.firstName} </span>
+              {/* I'd like better icons so we don't have to have a negative margin */}
+              <img style={{width:'50px', height:'50px', borderRadius:'50%', marginLeft: '-6px' }} src={Avatar} />
+              <span>{team.firstName}</span>
+              <div>{team.role}</div>
             </div>
           )
         });

--- a/app/containers/ProjectView/reducer.js
+++ b/app/containers/ProjectView/reducer.js
@@ -39,11 +39,13 @@ const initialState = fromJS({
     {
       firstName: 'John',
       lastName: 'Jon',
+      role: "Manager",
       picture: '1.jpg'
     },    
     {
       firstName: 'Elon',
       lastName: 'Eln',
+      role: "Assistant Manager",
       picture: '1.jpg'
     },
 
@@ -53,16 +55,19 @@ const initialState = fromJS({
     {
       firstName: 'Nizar',
       lastName: 'Niar',
+      role: "Gardener",
       picture: '1.jpg'
     },    
     {
       firstName: 'Max',
       lastName: 'Ma',
+      role: "Gardener",
       picture: '1.jpg'
     },
     {
       firstName: 'Mem',
       lastName: 'Me',
+      role: "General Laborer",
       picture: '1.jpg'
     },    
    


### PR DESCRIPTION
I added role subtitles to the icons in the team display.  It looks fine now, but I was forced to give the icons negative left margin to line them up with the subtitles.  In the future, we should probably not have icons with so much transparent padding.